### PR TITLE
Update map tile projection after resize

### DIFF
--- a/src/Geomap.js
+++ b/src/Geomap.js
@@ -118,7 +118,7 @@ export default class Geomap extends Viz {
     }
 
     const images = this._tileGroup.selectAll("image.tile")
-        .data(tileData, d => `${d.x}-${d.y}-${d.z}`);
+      .data(tileData, d => `${d.x}-${d.y}-${d.z}`);
 
     images.exit().transition().duration(duration)
       .attr("opacity", 0).remove();
@@ -126,19 +126,25 @@ export default class Geomap extends Viz {
     const scale = tileData.scale / transform.k;
 
     images.enter().append("image")
-        .attr("class", "tile")
-        .attr("opacity", 0)
-        .attr("xlink:href", d => this._tileUrl
-          .replace("{s}", ["a", "b", "c"][Math.random() * 3 | 0])
-          .replace("{z}", d.z)
-          .replace("{x}", d.x)
-          .replace("{y}", d.y))
-        .attr("width", scale)
-        .attr("height", scale)
-        .attr("x", d => d.x * scale + tileData.translate[0] * scale - transform.x / transform.k)
-        .attr("y", d => d.y * scale + tileData.translate[1] * scale - transform.y / transform.k)
+      .attr("class", "tile")
+      .attr("opacity", 0)
+      .attr("xlink:href", d => this._tileUrl
+        .replace("{s}", ["a", "b", "c"][Math.random() * 3 | 0])
+        .replace("{z}", d.z)
+        .replace("{x}", d.x)
+        .replace("{y}", d.y))
+      .attr("width", scale)
+      .attr("height", scale)
+      .attr("x", d => d.x * scale + tileData.translate[0] * scale - transform.x / transform.k)
+      .attr("y", d => d.y * scale + tileData.translate[1] * scale - transform.y / transform.k)
       .transition().duration(duration)
-        .attr("opacity", 1);
+      .attr("opacity", 1);
+
+    images
+      .attr("width", scale)
+      .attr("height", scale)
+      .attr("x", d => d.x * scale + tileData.translate[0] * scale - transform.x / transform.k)
+      .attr("y", d => d.y * scale + tileData.translate[1] * scale - transform.y / transform.k);
 
   }
 
@@ -172,11 +178,11 @@ export default class Geomap extends Viz {
 
     const ocean = this._container.selectAll("rect.d3plus-geomap-ocean").data([0]);
     ocean.enter().append("rect")
-        .attr("class", "d3plus-geomap-ocean")
+      .attr("class", "d3plus-geomap-ocean")
       .merge(ocean)
-        .attr("width", width)
-        .attr("height", height)
-        .attr("fill", this._ocean || "transparent");
+      .attr("width", width)
+      .attr("height", height)
+      .attr("fill", this._ocean || "transparent");
 
     this._tileGroup = this._container.selectAll("g.d3plus-geomap-tileGroup").data([0]);
     this._tileGroup = this._tileGroup.enter().append("g")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix #20 

### Description
<!--- Describe your changes in detail -->
The bug was caused because when the `x, y, z` dimensions didn't changed, the old tiles was persistents. 

I solved updating attributes in images:
```
images
      .attr("width", scale)
      .attr("height", scale)
      .attr("x", d => d.x * scale + tileData.translate[0] * scale - transform.x / transform.k)
      .attr("y", d => d.y * scale + tileData.translate[1] * scale - transform.y / transform.k);
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

